### PR TITLE
Add support for Android Apps

### DIFF
--- a/plugin.program.autowidget/resources/lib/menu.py
+++ b/plugin.program.autowidget/resources/lib/menu.py
@@ -241,6 +241,9 @@ def call_path(group_id, path_id):
             final_path = 'InstallFromZip'
         elif 'plugin.video.youtube' in path_def['path']:
             final_path = 'RunPlugin({})'.format(path_def['path'])
+        elif path_def['path'].startswith('androidapp://sources/apps/'):
+            final_path = 'StartAndroidActivity({})'.format(path_def['path']
+                                                           .replace('androidapp://sources/apps/', ''))
         else:
             final_path = 'PlayMedia({})'.format(path_def['path'])
     elif path_def['target'] == 'widget' or path_def['is_folder'] == 1 \


### PR DESCRIPTION
Android Apps can be added to groups, but it wasn't possible to start them.
This feature has been added with this PR. 