### PR TITLE
Fix bug spanish translation

### DIFF
--- a/plugin.program.autowidget/resources/language/resource.language.es_es/strings.po
+++ b/plugin.program.autowidget/resources/language/resource.language.es_es/strings.po
@@ -364,7 +364,7 @@ msgstr "Siempre"
 
 msgctxt "#32086"
 msgid "While Nothing Playing"
-msgstr "Mientras nada jugando"
+msgstr "Mientras no haya nada en reproducción"
 
 msgctxt "#32087"
 msgid "Never"


### PR DESCRIPTION
Thank you @drinfernoo. In spanish the verb to play is not the same as to reproduce. I have replaced 'Jugando' to 'Reproducción'.

Thank you again.