### PR TITLE
Fix edit widget and handle files with no art

### DIFF
--- a/plugin.program.autowidget/resources/lib/common/utils.py
+++ b/plugin.program.autowidget/resources/lib/common/utils.py
@@ -387,7 +387,7 @@ def get_files_list(path, titles=None):
             if 'art' in new_file:
                 for art in new_file['art']:
                     new_file['art'][art] = clean_artwork_url(file['art'][art])
-            new_files.append(new_file)
+                new_files.append(new_file)
         log(json.dumps(files), 'debug')
                 
         return new_files

--- a/plugin.program.autowidget/resources/lib/edit.py
+++ b/plugin.program.autowidget/resources/lib/edit.py
@@ -76,7 +76,7 @@ def _remove_path(path_id, group_id, over=False):
         manage.write_path(group_def)
 
 
-def remove_widget(widget_id, over=False):
+def _remove_widget(widget_id, over=False):
     if not over:
         choice = dialog.yesno('AutoWidget', utils.get_string(32039))
 


### PR DESCRIPTION
* Fix widget function name (`remove_widget` --> `_remove_widget`)
* Only add new files which have `art`